### PR TITLE
Fix translations

### DIFF
--- a/public/views/backup.html
+++ b/public/views/backup.html
@@ -20,8 +20,8 @@
   </nav>
 
   <div class="box-notification" ng-show="wordsC.error">
-    <span class="text-warning" translate>
-      {{wordsC.error}}
+    <span class="text-warning">
+      {{wordsC.error|translate}}
     </span>
   </div>
 

--- a/public/views/includes/password.html
+++ b/public/views/includes/password.html
@@ -38,5 +38,5 @@
       <i class="fi-alert"></i>
       <span ng-show="!error" translate> Your wallet key will be encrypted. The Spending Password cannot be recovered. Be sure to write it down</span>
 
-      <span ng-show="error" translate>{{error}}</span>
+      <span ng-show="error">{{error|translate}}</span>
     </p>

--- a/public/views/modals/addressbook.html
+++ b/public/views/modals/addressbook.html
@@ -97,7 +97,7 @@
           <div ng-show="addAddressbookEntry">
             <h4 translate>Add a new entry</h4>
             <form name="addressbookForm" class="p10" no-validate>
-              <div class="text-warning size-12 m10b" ng-show="error" translate>{{error}}</div>
+              <div class="text-warning size-12 m10b" ng-show="error">{{error|translate}}</div>
               <span ng-hide="addressbookForm.address.$pristine">
                 <span class="has-error right size-12" ng-show="addressbookForm.address.$invalid && addressbook.address">
                   <i class="icon-close-circle size-14"></i>

--- a/public/views/modals/txp-details.html
+++ b/public/views/modals/txp-details.html
@@ -14,7 +14,7 @@
   <div class="onGoingProcess" ng-show="loading">
     <div class="onGoingProcess-content" ng-style="{'background-color':index.backgroundColor}">
       <ion-spinner class="spinner-stable" icon="lines"></ion-spinner>
-      <span translate>{{loading}}</span>
+      <span>{{loading|translate}}</span>
     </div>
   </div>
 
@@ -33,7 +33,7 @@
 
       <div class="oh">
         <div class="box-notification" ng-show="error">
-          <span class="text-warning size-14" translate>{{error}}</span>
+          <span class="text-warning size-14">{{error|translate}}</span>
         </div>
 
         <div class="row" ng-if="tx.removed">
@@ -162,7 +162,7 @@
               <i ng-if="ac.type == 'reject'" class="fi-x icon-sign x db"></i>
               <i ng-if="ac.type == 'accept'" class="fi-check icon-sign check db"></i>
             </span>
-            {{ac.copayerName}} <span ng-if="ac.copayerId == copayerId" translate>({{'Me'}})</span>
+            {{ac.copayerName}} <span ng-if="ac.copayerId == copayerId">({{'Me'|translate}})</span>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
Without this we have the additions of this kinds of strings in the .pot file after a `grunt translate`:

```
msgid "{{loading}}"
msgstr ""

#: public/views/backup.html
msgid "{{wordsC.error}}"
msgstr ""
```

You can close this pull request and make the changes yourself if you want.
